### PR TITLE
Fix mod incompatibilities

### DIFF
--- a/src/main/java/dev/cxntered/rankspoof/mixin/compatibility/ScoreboardMixin_VanillaHUD.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/compatibility/ScoreboardMixin_VanillaHUD.java
@@ -1,0 +1,63 @@
+package dev.cxntered.rankspoof.mixin.compatibility;
+
+import dev.cxntered.rankspoof.config.Config;
+import net.minecraft.scoreboard.ScorePlayerTeam;
+import net.minecraft.scoreboard.Team;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Pseudo
+@Mixin(targets = "org.polyfrost.vanillahud.hud.Scoreboard$ScoreboardHUD", remap = false)
+public abstract class ScoreboardMixin_VanillaHUD {
+    @Unique
+    private String rankspoof$getRank() {
+        return Config.getInstance().spoofedRank
+                .replace('&', '§')
+                .replace("[", "")
+                .replace("]", "");
+    }
+
+    @Dynamic("VanillaHUD")
+    @Redirect(
+            method = "renderObjective",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/scoreboard/ScorePlayerTeam;formatPlayerName(Lnet/minecraft/scoreboard/Team;Ljava/lang/String;)Ljava/lang/String;",
+                    ordinal = 0,
+                    remap = true
+            )
+    )
+    private String rankspoof$spoofScoreboardRankWidth(Team team, String string) {
+        String scoreboardLine = ScorePlayerTeam.formatPlayerName(team, string);
+
+        if (Config.getInstance().enabled && scoreboardLine.matches("Rank: .+")) {
+            return "Rank: " + rankspoof$getRank();
+        }
+
+        return scoreboardLine;
+    }
+
+    @Dynamic("VanillaHUD")
+    @Redirect(
+            method = "renderObjective",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/scoreboard/ScorePlayerTeam;formatPlayerName(Lnet/minecraft/scoreboard/Team;Ljava/lang/String;)Ljava/lang/String;",
+                    ordinal = 1,
+                    remap = true
+            )
+    )
+    private String rankspoof$spoofScoreboardRank(Team team, String string) {
+        String scoreboardLine = ScorePlayerTeam.formatPlayerName(team, string);
+
+        if (Config.getInstance().enabled && scoreboardLine.matches("Rank: .+")) {
+            return "Rank: " + rankspoof$getRank();
+        }
+
+        return scoreboardLine;
+    }
+}

--- a/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinFontRenderer.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinFontRenderer.java
@@ -1,4 +1,4 @@
-package dev.cxntered.rankspoof.mixin;
+package dev.cxntered.rankspoof.mixin.minecraft;
 
 import dev.cxntered.rankspoof.RankSpoof;
 import dev.cxntered.rankspoof.config.Config;
@@ -11,23 +11,15 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public abstract class MixinFontRenderer {
     @ModifyVariable(method = "renderString", at = @At("HEAD"), argsOnly = true)
     private String rankspoof$spoofRenderString(String string) {
-        if (string == null)
-            return null;
-
-        if (Config.getInstance().enabled)
-            string = RankSpoof.getSpoofedText(string);
-
+        if (string == null) return null;
+        if (Config.getInstance().enabled) return RankSpoof.getSpoofedText(string);
         return string;
     }
 
     @ModifyVariable(method = "getStringWidth", at = @At("HEAD"), argsOnly = true)
     private String rankspoof$spoofGetStringWidth(String string) {
-        if (string == null)
-            return null;
-
-        if (Config.getInstance().enabled)
-            string = RankSpoof.getSpoofedText(string);
-
+        if (string == null) return null;
+        if (Config.getInstance().enabled) return RankSpoof.getSpoofedText(string);
         return string;
     }
 }

--- a/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiIngame.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiIngame.java
@@ -1,4 +1,4 @@
-package dev.cxntered.rankspoof.mixin;
+package dev.cxntered.rankspoof.mixin.minecraft;
 
 import dev.cxntered.rankspoof.config.Config;
 import net.minecraft.client.gui.GuiIngame;
@@ -15,7 +15,7 @@ public abstract class MixinGuiIngame {
                     .replace('&', '§')
                     .replace("[", "")
                     .replace("]", "");
-            string = "Rank: " + rank;
+            return "Rank: " + rank;
         }
 
         return string;

--- a/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiIngame.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiIngame.java
@@ -2,15 +2,25 @@ package dev.cxntered.rankspoof.mixin.minecraft;
 
 import dev.cxntered.rankspoof.config.Config;
 import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.scoreboard.ScorePlayerTeam;
+import net.minecraft.scoreboard.Team;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(GuiIngame.class)
 public abstract class MixinGuiIngame {
-    @ModifyVariable(method = "renderScoreboard", at = @At(value = "STORE"), index = 15)
-    private String rankspoof$spoofScoreboardRank(String string) {
-        if (Config.getInstance().enabled && string.matches("Rank: .+")) {
+    @Redirect(
+            method = "renderScoreboard",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/scoreboard/ScorePlayerTeam;formatPlayerName(Lnet/minecraft/scoreboard/Team;Ljava/lang/String;)Ljava/lang/String;"
+            )
+    )
+    private String rankspoof$spoofScoreboardRank(Team team, String string) {
+        String formattedString = ScorePlayerTeam.formatPlayerName(team, string);
+
+        if (Config.getInstance().enabled && formattedString.startsWith("Rank: ")) {
             String rank = Config.getInstance().spoofedRank
                     .replace('&', '§')
                     .replace("[", "")
@@ -18,6 +28,6 @@ public abstract class MixinGuiIngame {
             return "Rank: " + rank;
         }
 
-        return string;
+        return formattedString;
     }
 }

--- a/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiScreen.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiScreen.java
@@ -1,4 +1,4 @@
-package dev.cxntered.rankspoof.mixin;
+package dev.cxntered.rankspoof.mixin.minecraft;
 
 import dev.cxntered.rankspoof.config.Config;
 import net.minecraft.client.gui.GuiScreen;

--- a/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiScreen.java
+++ b/src/main/java/dev/cxntered/rankspoof/mixin/minecraft/MixinGuiScreen.java
@@ -1,34 +1,28 @@
 package dev.cxntered.rankspoof.mixin.minecraft;
 
 import dev.cxntered.rankspoof.config.Config;
+import gg.essential.lib.mixinextras.sugar.Local;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Mixin(GuiScreen.class)
 public abstract class MixinGuiScreen {
-    @Inject(
+    @Redirect(
             method = "renderToolTip",
             at = @At(
                     value = "INVOKE",
                     target = "Ljava/util/List;set(ILjava/lang/Object;)Ljava/lang/Object;",
-                    ordinal = 1, shift = At.Shift.AFTER
-            ),
-            locals = LocalCapture.CAPTURE_FAILSOFT
+                    ordinal = 1
+            )
     )
-    private void rankspoof$spoofTooltipRank(ItemStack stack, int x, int y, CallbackInfo ci, List<String> list, int i) {
+    private Object rankspoof$spoofTooltipRank(List<String> list, int i, Object object, @Local(argsOnly = true) ItemStack stack) {
         if (Config.getInstance().enabled && stack.getDisplayName().equals("§aCharacter Information")) {
-            Pattern pattern = Pattern.compile("§7Rank: .+");
-            Matcher matcher = pattern.matcher(list.get(i));
-            if (!matcher.find()) return;
+            if (!list.get(i).startsWith("§5§o§7Rank: ")) return object;
 
             String rank = Config.getInstance().spoofedRank
                     .replace('&', '§')
@@ -36,5 +30,7 @@ public abstract class MixinGuiScreen {
                     .replace("]", "");
             list.set(i, "§7Rank: " + rank);
         }
+
+        return object;
     }
 }


### PR DESCRIPTION
Fixes mod incompatibilities with VanillaHUD, Skytils, and ChatTriggers, which previously broke scoreboard and tooltip rank spoofing. Closes #1.

### Changes
- Mixin to VanillaHUD's scoreboard in order to spoof.
  - Includes refactoring mixin structure (woohoo!)
- Replace `@ModifyVariable` and `@Inject` mixins with `@Redirect`
  - I know redirect mixins should be avoided, but I have no clue how to go about this without it since it seems like the ASM transformers get applied first and mess up the mixin targets. If anyone has any clue on a better way to do it, please make a PR.
- Indirectly fix scoreboard text width spoofing.